### PR TITLE
Fix Card:generate_UIBox_ability_table(true)

### DIFF
--- a/JokerSellValue.lua
+++ b/JokerSellValue.lua
@@ -1,6 +1,6 @@
 local generate_UIBox_ability_table_ref = Card.generate_UIBox_ability_table
-function Card:generate_UIBox_ability_table()
-    local generate_UIBox_ability_table_val = generate_UIBox_ability_table_ref(self)
+function Card:generate_UIBox_ability_table(vars_only)
+    local generate_UIBox_ability_table_val = generate_UIBox_ability_table_ref(self, vars_only)
 
     if generate_UIBox_ability_table_val == nil then
         return


### PR DESCRIPTION
In [SMODS ALPHA 1312b](https://github.com/Steamodded/smods/commit/76edb86a4e73723d6dda81b03fac9796706f7947), `Card:generate_UIBox_ability_table` gained a `vars_only` parameter that allows for getting loc vars for any joker directly. The hook that's used for this function now passes this parameter through to the original function.

A case where I have found this necessary is with [Strange Pencil](https://github.com/DigitalDetective47/strange-pencil)'s [Peter Explains the Joker](https://github.com/DigitalDetective47/strange-pencil/commit/71d213879d23e8e50bda21ddb633769a4736ee19). This joker behaves as intended without JokerSellValue, and with this new PR, but crashes with the existing version of the mod.